### PR TITLE
use GMT timestamp for dynamic update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ However the AJAX update will fetch the latest ticks and update cached tickers  d
 
 ## Changelog
 
+### 1.1.0 - unreleased
+
+* Use GMT for automatic updates 
+
 ### 1.0.0 - 2018-11-02
 
 * Initial release

--- a/includes/class-scliveticker-widget.php
+++ b/includes/class-scliveticker-widget.php
@@ -73,7 +73,7 @@ class SCLiveticker_Widget extends WP_Widget {
 			echo ' sclt-widget-ajax" '
 				. 'data-sclt-ticker="' . esc_attr( $category ) . '" '
 				. 'data-sclt-limit="' . esc_attr( $count ) . '" '
-				. 'data-sclt-last="' . esc_attr( current_time( 'timestamp' ) );
+				. 'data-sclt-last="' . esc_attr( current_datetime()->getTimestamp() );
 		}
 		echo '">';
 

--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -203,7 +203,7 @@ class SCLiveticker {
 				$output .= ' sclt-ticker-ajax" '
 							. 'data-sclt-ticker="' . $ticker . '" '
 							. 'data-sclt-limit="' . $limit . '" '
-							. 'data-sclt-last="' . current_time( 'timestamp' );
+							. 'data-sclt-last="' . current_datetime()->getTimestamp();
 			}
 			$output .= '">';
 
@@ -317,7 +317,13 @@ class SCLiveticker {
 					}
 
 					$limit     = ( isset( $update_req['l'] ) ) ? intval( $update_req['l'] ) : - 1;
-					$last_poll = ( isset( $update_req['t'] ) ) ? intval( $update_req['t'] ) : 0;
+					$last_poll = explode(
+						',',
+						gmdate(
+							'Y,m,d,H,i,s',
+							( isset( $update_req['t'] ) ) ? intval( $update_req['t'] ) : 0
+						)
+					);
 
 					// Query new ticks from DB.
 					$query_args = array(
@@ -331,7 +337,15 @@ class SCLiveticker {
 							),
 						),
 						'date_query'     => array(
-							'after' => date( 'c', $last_poll ),
+							'column' => 'post_date_gmt',
+							'after'  => array(
+								'year'   => intval( $last_poll[0] ),
+								'month'  => intval( $last_poll[1] ),
+								'day'    => intval( $last_poll[2] ),
+								'hour'   => intval( $last_poll[3] ),
+								'minute' => intval( $last_poll[4] ),
+								'second' => intval( $last_poll[5] ),
+							),
 						),
 					);
 
@@ -351,13 +365,13 @@ class SCLiveticker {
 						$res[] = array(
 							'w' => $slug,
 							'h' => $out,
-							't' => current_time( 'timestamp' ),
+							't' => current_datetime()->getTimestamp(),
 						);
 					} else {
 						$res[] = array(
 							's' => $slug,
 							'h' => $out,
-							't' => current_time( 'timestamp' ),
+							't' => current_datetime()->getTimestamp(),
 						);
 					}
 				}


### PR DESCRIPTION
Use real unix timestamps and do not rely on the system timezone.
We now query the `post_date_gmt` field and use timestamps without zone bias.