### PR TITLE
raise required PHP version to 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 * Contributors:      Stefan Kalscheuer
 * Tags:              liveticker, feed, rss
 * Requires at least: 4.0
-* Tested up to:      5.3
-* Requires PHP:      5.2
+* Tested up to:      5.4
+* Requires PHP:      5.6
 * Stable tag:        1.0.0
 * License:           GPLv2 or later
 * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,7 @@ caching time of 12 hours obviously makes no sense.
 
 ### 1.1.0 - unreleased
 
+* Requires PHP 5.6 or above
 * Use GMT for automatic updates 
 * Gutenberg Block available
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -95,6 +95,8 @@ class RoboFile extends Tasks {
 	/**
 	 * Run code style tests
 	 *
+	 * @param array $opts Options.
+	 *
 	 * @return void
 	 */
 	public function testCS(
@@ -109,7 +111,7 @@ class RoboFile extends Tasks {
 		$this->say( 'Executing PHPCS...' );
 		$this->_exec( __DIR__ . '/vendor/bin/phpcs --standard=phpcs.xml -s' );
 
-		if ( $opts[self::OPT_NODE] ) {
+		if ( $opts[ self::OPT_NODE ] ) {
 			$this->say( 'Executing ESLint...' );
 			$this->_exec( __DIR__ . '/node_modules/eslint/bin/eslint.js ' . __DIR__ . '/scripts/block.js' );
 			$this->_exec( __DIR__ . '/node_modules/eslint/bin/eslint.js ' . __DIR__ . '/scripts/liveticker.js' );
@@ -145,7 +147,7 @@ class RoboFile extends Tasks {
 		if ( isset( $opts[ self::OPT_SKIPSTYLE ] ) && true === $opts[ self::OPT_SKIPSTYLE ] ) {
 			$this->say( 'Style checks skipped' );
 		} else {
-			$this->testCS($opts);
+			$this->testCS( $opts );
 		}
 		$this->bundle();
 	}
@@ -157,21 +159,23 @@ class RoboFile extends Tasks {
 	 */
 	private function bundle() {
 		$this->say( 'Bundling resources...' );
-		$this->taskCopyDir( array(
-			'includes' => $this->target_dir . '/' . $this->final_name . '/includes',
-			'scripts'  => $this->target_dir . '/' . $this->final_name . '/scripts',
-			'styles'   => $this->target_dir . '/' . $this->final_name . '/styles',
-			'views'    => $this->target_dir . '/' . $this->final_name . '/views',
-		) )->run();
+		$this->taskCopyDir(
+			array(
+				'includes' => $this->target_dir . '/' . $this->final_name . '/includes',
+				'scripts'  => $this->target_dir . '/' . $this->final_name . '/scripts',
+				'styles'   => $this->target_dir . '/' . $this->final_name . '/styles',
+				'views'    => $this->target_dir . '/' . $this->final_name . '/views',
+			)
+		)->run();
 		$this->_copy( 'stklcode-liveticker.php', $this->target_dir . '/' . $this->final_name . '/stklcode-liveticker.php' );
 		$this->_copy( 'README.md', $this->target_dir . '/' . $this->final_name . '/README.md' );
 		$this->_copy( 'LICENSE.md', $this->target_dir . '/' . $this->final_name . '/LICENSE.md' );
 
 		// Remove content before title (e.g. badges) from README file.
 		$this->taskReplaceInFile( $this->target_dir . '/' . $this->final_name . '/README.md' )
-		     ->regex( '/^[^\\#]*/' )
-		     ->to( '' )
-		     ->run();
+			->regex( '/^[^\\#]*/' )
+			->to( '' )
+			->run();
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
   ],
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=5.2",
+    "php": ">=5.6",
     "composer/installers": "~1.7"
   },
   "require-dev": {
-    "php": ">=5.2",
+    "php": ">=7",
     "consolidation/robo": "^2",
     "phpunit/phpunit": "*",
     "phpunit/php-code-coverage": "*",

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -4,8 +4,10 @@
  *
  * This file contains the derived class for the plugin's administration features.
  *
- * @package Liveticker
+ * @package SCLiveticker
  */
+
+namespace SCLiveticker;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Liveticker admin configuration.
  */
-class SCLiveticker_Admin extends SCLiveticker {
+class Admin extends SCLiveticker {
 	/**
 	 * Add to Right Now Widget
 	 *

--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -4,13 +4,18 @@
  *
  * This file contains the plugin's base class.
  *
- * @package Liveticker
+ * @package SCLiveticker
  */
+
+namespace SCLiveticker;
+
+use WP_Query;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
 
 /**
  * Liveticker.
@@ -92,11 +97,11 @@ class SCLiveticker {
 		// Admin only actions.
 		if ( is_admin() ) {
 			// Add dashboard "right now" functionality.
-			add_action( 'right_now_content_table_end', array( 'SCLiveticker_Admin', 'dashboard_right_now' ) );
+			add_action( 'right_now_content_table_end', array( 'SCLiveticker\\Admin', 'dashboard_right_now' ) );
 
 			// Settings.
-			add_action( 'admin_init', array( 'SCLiveticker_Admin', 'register_settings' ) );
-			add_action( 'admin_menu', array( 'SCLiveticker_Admin', 'register_settings_page' ) );
+			add_action( 'admin_init', array( 'SCLiveticker\\Admin', 'register_settings' ) );
+			add_action( 'admin_menu', array( 'SCLiveticker\\Admin', 'register_settings_page' ) );
 		}
 	}
 
@@ -457,19 +462,7 @@ class SCLiveticker {
 	 * @since 1.1
 	 */
 	private static function block_present() {
-		// We are in WP 5.x environment and blocks are generally present.
-		if ( function_exists( 'has_blocks' ) && has_blocks() ) {
-			/*
-			 * The slightly faster call to ‌has_block( 'scliveticker/ticker' ) produces an "undefined function" error for
-			 * no good reason. Iteration over pased blocks however works fine.
-			 */
-			foreach ( parse_blocks( get_post()->post_content ) as $b ) {
-				if ( 'scliveticker/ticker' === $b['blockName'] ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return function_exists( 'has_block' ) && // We are in WP 5.x environment.
+			has_block( 'scliveticker/ticker' ); // Specific block is present.
 	}
 }

--- a/includes/class-system.php
+++ b/includes/class-system.php
@@ -4,8 +4,12 @@
  *
  * This file contains the derived class for the plugin's system operations.
  *
- * @package Liveticker
+ * @package SCLiveticker
  */
+
+namespace SCLiveticker;
+
+use WP_Query;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  *  Liveticker system configuration.
  */
-class SCLiveticker_System extends SCLiveticker {
+class System extends SCLiveticker {
 
 	/**
 	 * Activation hook.

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -4,17 +4,22 @@
  *
  * This file contains the liveticker widget.
  *
- * @package Liveticker
+ * @package SCLiveticker
  */
+
+namespace SCLiveticker;
+
+use WP_Query;
+use WP_Widget;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Class SCLiveticker_Widget.
+ * Class Widget.
  */
-class SCLiveticker_Widget extends WP_Widget {
+class Widget extends WP_Widget {
 
 	/**
 	 * SCLiveticker_Widget constructor.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,6 @@
 	</rule>
 
 	<!-- PHP compatibility level -->
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibility"/>
 </ruleset>

--- a/stklcode-liveticker.php
+++ b/stklcode-liveticker.php
@@ -41,22 +41,22 @@ define( 'SCLIVETICKER_BASE', plugin_dir_url( __FILE__ ) );
 define( 'SCLIVETICKER_BASENAME', plugin_basename( __FILE__ ) );
 
 // System Hooks.
-add_action( 'init', array( 'SCLiveticker', 'register_types' ) );
-add_action( 'plugins_loaded', array( 'SCLiveticker', 'init' ) );
-register_activation_hook( SCLIVETICKER_FILE, array( 'SCLiveticker_System', 'activate' ) );
-register_uninstall_hook( SCLIVETICKER_FILE, array( 'SCLiveticker_System', 'uninstall' ) );
+add_action( 'init', array( 'SCLiveticker\\SCLiveticker', 'register_types' ) );
+add_action( 'plugins_loaded', array( 'SCLiveticker\\SCLiveticker', 'init' ) );
+register_activation_hook( SCLIVETICKER_FILE, array( 'SCLiveticker\\System', 'activate' ) );
+register_uninstall_hook( SCLIVETICKER_FILE, array( 'SCLiveticker\\System', 'uninstall' ) );
 
 // Allow shortcodes in widgets.
 add_filter( 'widget_text', 'do_shortcode' );
 
 // Add shortcode.
-add_shortcode( 'liveticker', array( 'SCLiveticker', 'shortcode_ticker_show' ) );
+add_shortcode( 'liveticker', array( 'SCLiveticker\\SCLiveticker', 'shortcode_ticker_show' ) );
 
 // Add Widget.
-add_action( 'widgets_init', array( 'SCLiveticker_Widget', 'register' ) );
+add_action( 'widgets_init', array( 'SCLiveticker\\Widget', 'register' ) );
 
 // Add Gutenberg block.
-add_action( 'enqueue_block_editor_assets', array( 'SCLiveticker_Admin', 'register_block' ) );
+add_action( 'enqueue_block_editor_assets', array( 'SCLiveticker\\Admin', 'register_block' ) );
 
 // Autoload.
 spl_autoload_register( 'scliveticker_autoload' );
@@ -70,16 +70,16 @@ spl_autoload_register( 'scliveticker_autoload' );
  */
 function scliveticker_autoload( $class ) {
 	$plugin_classes = array(
-		'SCLiveticker',
-		'SCLiveticker_Admin',
-		'SCLiveticker_System',
-		'SCLiveticker_Widget',
+		'SCLiveticker\\SCLiveticker',
+		'SCLiveticker\\Admin',
+		'SCLiveticker\\System',
+		'SCLiveticker\\Widget',
 	);
 	if ( in_array( $class, $plugin_classes, true ) ) {
 		require_once sprintf(
 			'%s/includes/class-%s.php',
 			SCLIVETICKER_DIR,
-			strtolower( str_replace( '_', '-', $class ) )
+			strtolower( str_replace( '_', '-', substr( $class, 13 ) ) )
 		);
 	}
 }


### PR DESCRIPTION
WordPress 5 has PHP 5.6 as minimum requirement, so we are safe to raise the level here.
WP 4 still has support for PHP down to 5.2, so we break compatibility here - although there are assumingly very few sites running such outdated environments.

With some WP5 checks like `has_block()` namespace issues do occur, i.e. `has_block()` triggers a "Call to undefined function" error even if `function_exists( 'has_block' )` resoltes to `true`. Prepending root namespace `\has_block()` performs fine on PHP 7 test sites, however breaks compatibility with PHP 5.2 itself, as namespaces have been introduced in 5.3.

We don't wanna mess around with such "antique" PHP, so we raise the level straight up to 5.6.

As part of this change, all classes are now embedded in the `SCLiveticker` namespace.