### PR TITLE
use time() instead of current_datetime() for WP 4.x compatibility

### DIFF
--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -206,7 +206,7 @@ class SCLiveticker {
 				$output .= ' sclt-ajax" '
 							. 'data-sclt-ticker="' . $ticker . '" '
 							. 'data-sclt-limit="' . $limit . '" '
-							. 'data-sclt-last="' . current_datetime()->getTimestamp();
+							. 'data-sclt-last="' . time();
 			}
 			$output .= '"><ul>';
 
@@ -362,13 +362,13 @@ class SCLiveticker {
 						$res[] = array(
 							'w' => $slug,
 							'h' => $out,
-							't' => current_datetime()->getTimestamp(),
+							't' => time(),
 						);
 					} else {
 						$res[] = array(
 							's' => $slug,
 							'h' => $out,
-							't' => current_datetime()->getTimestamp(),
+							't' => time(),
 						);
 					}
 				}


### PR DESCRIPTION
Fixes regression from #3 (use GMT timestamp for dynamic update)

The function `current_datetime()` has been introduced in WP 5.3, but the Plugin should maintain compatibility with 4.x for now. No idea why this has not been caught by PHPCS, but that's what manual testing is for...

We now simply use PHP's `time()` instead of reverting to `current_time( 'timestamp' )` which is rather misleading.