### PR TITLE
expose ticks through REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ caching time of 12 hours obviously makes no sense.
 * Requires PHP 5.6 or above
 * Use GMT for automatic updates 
 * Gutenberg Block available
+* Ticks exposed through REST API
 
 ### 1.0.0 - 2018-11-02
 

--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -165,6 +165,7 @@ class SCLiveticker {
 			'supports'           => array( 'title', 'editor', 'author' ),
 			'taxonomies'         => array( 'scliveticker_ticker' ),
 			'has_archive'        => true,
+			'show_in_rest'       => true,
 		);
 
 		register_post_type( 'scliveticker_tick', $args );


### PR DESCRIPTION
Tickers are already exposed for JS integration in Gutenberg (#2). Now ticks themselves are also available for use with external systems.