### PR TITLE
prepend list elements instead of replacing HTML body on AJAX update

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ caching time of 12 hours obviously makes no sense.
 * Use GMT for automatic updates 
 * Gutenberg Block available
 * Ticks exposed through REST API
+* Changed AJAX update logic for embedded media compatibility
 
 ### 1.0.0 - 2018-11-02
 

--- a/scripts/liveticker.js
+++ b/scripts/liveticker.js
@@ -164,8 +164,15 @@
 	 * @return {void}
 	 */
 	var updateHTML = function( t, u ) {
-		// Prepend HTML of new ticks.
-		t.e.innerHTML = u.h + t.e.innerHTML;
+		// Parse new DOM-part.
+		var n = document.createElement( 'ul' );
+		n.innerHTML = u.h;
+
+		// Prepend new ticks to container.
+		while ( n.hasChildNodes() ) {
+			t.e.prepend( n.lastChild );
+		}
+
 		t.e.parentNode.setAttribute( 'data-sclt-last', u.t );
 
 		// Remove tail, if limit is set.


### PR DESCRIPTION
Resolves #9

Replacing the body by prepending HTML results in the full content being re-rendered. This can be a performance issue, but is definitely annoying when embedding media in ticks.

We now create a temporary node and move each child node to the container instead of replacing `innerHTML`. More elegant spread operator solution ( `t.e.prepend( ...n.childNodes )` )not used by intention, as it breaks IE support (there's always someone who still need is).