### PR TITLE
fix: cast string to Number when setting attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ caching time of 12 hours obviously makes no sense.
 
 ## Changelog
 
-### 1.2.0 - 2022-02-01
+### 1.2.1 - 2022-02-01
 
 * Fix issue with limit in Gutenberg block.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ caching time of 12 hours obviously makes no sense.
 
 ## Changelog
 
+### 1.2.0 - 2022-02-01
+
+* Fix issue with limit in Gutenberg block.
+
 ### 1.2.0 - 2022-01-23
 
 * Requires WordPress 4.7 or above

--- a/scripts/block.js
+++ b/scripts/block.js
@@ -152,7 +152,7 @@
 							disabled: props.attributes.unlimited,
 							value: props.attributes.limit,
 							onChange: function( val ) {
-								props.setAttributes( { limit: val } );
+								props.setAttributes( { limit: Number( val ) } );
 							},
 						}
 					),


### PR DESCRIPTION
Block validation fails when you change the `limit` attribute on a Liveticker Gutenberg block and save the post. When you refresh it will fail because we need to cast it to a `Number` before saving to the attributes.
![image](https://user-images.githubusercontent.com/3067041/151987033-35fa86fa-fd98-4d5a-b6d9-21859d27306a.png)
