### PR TITLE
add a note on cross-site-scripting to JS feature description

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -243,7 +243,9 @@ class Settings extends SCLiveticker {
 			'embedded-script',
 			'[embedded_script]',
 			self::$options['embedded_script'],
-			__( 'Allow embedded script evaluation in tick contents. This might be useful for embedded content, e.g. social media integrations.', 'stklcode-liveticker' ),
+			__( 'Allow embedded script evaluation in tick contents. This might be useful for embedded content, e.g. social media integrations.', 'stklcode-liveticker' ) .
+			' ' .
+			__( 'Be aware that this feature potentially enables cross-site scripting, so make sure content is created by trusted people and only enable this if required.', 'stklcode-liveticker' ),
 			__( 'Allow JavaScript in tick content', 'stklcode-liveticker' )
 		);
 	}


### PR DESCRIPTION
The feature has always been a trade-off between feature and security and we don't know how many sites actually make use of it. It's disabled by default.

Raise the awareness and add some words of warning to the description.