### PR TITLE
use add_action() instead of add_filter() for rest_api_init

### DIFF
--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -72,7 +72,7 @@ class SCLiveticker {
 		self::update_options();
 
 		// Add filter for REST API queries.
-		add_filter( 'rest_api_init', array( 'SCLiveticker\\Api', 'init' ) );
+		add_action( 'rest_api_init', array( 'SCLiveticker\\Api', 'init' ) );
 		add_filter( 'rest_scliveticker_tick_query', array( 'SCLiveticker\\Api', 'tick_query_filter' ), 10, 2 );
 
 		// Skip on AJAX if not enabled.


### PR DESCRIPTION
The `rest_api_init` hook [1] is an action hook and should be used as such. Replace `add_filter()` with `add_action()` to register our init method.

----

[1] https://developer.wordpress.org/reference/hooks/rest_api_init/