### PR TITLE
remove explicit call to load_plugin_textdomain

### DIFF
--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -80,9 +80,6 @@ class SCLiveticker {
 			return;
 		}
 
-		// Load Textdomain.
-		load_plugin_textdomain( 'stklcode-liveticker' );
-
 		// Allow shortcodes in widgets.
 		add_filter( 'widget_text', 'do_shortcode' );
 


### PR DESCRIPTION
Loading the textdomain explicitly is not required for plugins hosted on w.org since WordPress 4.6. Remove the call from our init routine.

Calling it during `plugins_loaded` was likely too early anyway, but as it is not required at all, removing should resolve both.