### PR TITLE
use wp_doing_ajax() instead of checking for global constant

### DIFF
--- a/includes/class-scliveticker.php
+++ b/includes/class-scliveticker.php
@@ -76,7 +76,7 @@ class SCLiveticker {
 		add_filter( 'rest_scliveticker_tick_query', array( 'SCLiveticker\\Api', 'tick_query_filter' ), 10, 2 );
 
 		// Skip on AJAX if not enabled.
-		if ( ( ! isset( self::$options['enable_ajax'] ) || 1 !== self::$options['enable_ajax'] ) && ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+		if ( ( ! isset( self::$options['enable_ajax'] ) || 1 !== self::$options['enable_ajax'] ) && wp_doing_ajax() ) {
 			return;
 		}
 


### PR DESCRIPTION
The function is available since WP 4.7[1], so we could have been using it since v1.2. It defaults to the same logic but applies an additional filter internally.

----
[1] https://developer.wordpress.org/reference/functions/wp_doing_ajax/