### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ A complete list of the available tasks and options can be shown by running `robo
 This project, as part of the WordPress ecosystem adheres to the [WordPress Coding Standards](https://codex.wordpress.org/WordPress_Coding_Standards).
 Please make sure that you are at least roughly familiar with those guidelines.
 
-The code style is automatically checked for commits (including pull requests) using [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+The code style is automatically checked for commits (including pull requests) using [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 You can check your code against the configured ruleset yourself by running
  `./vendor/bin/phpcs --standard=phpcs.xml your-edited-file.php` (assuming `composer install` has been executed) or the Robo task `robo test:cs` for a complete scan.
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932